### PR TITLE
add force_basic_auth to module defaults

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,8 @@ authors:
   - Christopher Grau <christopher.grau@t-systems.com>
   - Daniel Uhlmann <daniel.uhlmann@t-systems.com>
 description: >-
-  This collection serves as a kind of 'meta collection' for roles and collections, which are used for the configuration and administration of individual components of Icinga. 
+  This collection serves as a kind of 'meta collection' for roles and collections, which are used for the
+  configuration and administration of individual components of Icinga.
   Additionally, this collection is used to install the Icinga agent and roll out custom checks for every agent.
 dependencies:
   t_systems_mms.icinga_director: "*"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,8 @@ authors:
   - Christopher Grau <christopher.grau@t-systems.com>
   - Daniel Uhlmann <daniel.uhlmann@t-systems.com>
 description: >-
-  This collection serves as a kind of 'meta collection' for roles and collections, which are used for the configuration and administration of individual components of Icinga. Additionally, this collection is used to install the Icinga agent and roll out custom checks for every agent.
+  This collection serves as a kind of 'meta collection' for roles and collections, which are used for the configuration and administration of individual components of Icinga. 
+  Additionally, this collection is used to install the Icinga agent and roll out custom checks for every agent.
 dependencies:
   t_systems_mms.icinga_director: "*"
   t_systems_mms.icinga_business_process: "*"

--- a/playbooks/check_azure_oauth_token.yml
+++ b/playbooks/check_azure_oauth_token.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create command Azure oauth token
       telekom_mms.icinga_director.icinga_command:

--- a/playbooks/check_gitlab_scheduler.yml
+++ b/playbooks/check_gitlab_scheduler.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create command for check_gitlab_scheduler
       telekom_mms.icinga_director.icinga_command:

--- a/playbooks/check_https.yml
+++ b/playbooks/check_https.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create service template for mms-https
       telekom_mms.icinga_director.icinga_service_template:

--- a/playbooks/check_json.yml
+++ b/playbooks/check_json.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create Command check_json
       telekom_mms.icinga_director.icinga_command:

--- a/playbooks/check_json_azure_restapi.yml
+++ b/playbooks/check_json_azure_restapi.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create command Azure REST-API
       telekom_mms.icinga_director.icinga_command:

--- a/playbooks/check_json_azure_restapi_resourcehealth.yml
+++ b/playbooks/check_json_azure_restapi_resourcehealth.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create service template for azure REST-API ResourceHealth
       telekom_mms.icinga_director.icinga_service_template:

--- a/playbooks/mms_standard.yml
+++ b/playbooks/mms_standard.yml
@@ -6,6 +6,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create timeperiod for mms-standard-service
       telekom_mms.icinga_director.icinga_timeperiod:

--- a/playbooks/template_empty_host.yml
+++ b/playbooks/template_empty_host.yml
@@ -7,6 +7,7 @@
       url: "{{ icinga_url }}"
       url_username: "{{ icinga_user }}"
       url_password: "{{ icinga_pass }}"
+      force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
   tasks:
     - name: Create a host in icinga
       telekom_mms.icinga_director.icinga_host_template:


### PR DESCRIPTION
force_basic_auth is needed for communication with Icinga Director which is probably sitting behind a basic authentication prompt.