### PR TITLE
fix: bug icinga debian11 repo key

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,16 +97,9 @@ jobs:
           testing-type: integration
           test-deps: telekom_mms.icinga_director
 
-  linting:
+  call-linting:
     name: Ansible Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run Linting
-        uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528 # v26
+    uses: telekom-mms/.github/.github/workflows/ansible-lint.yml@main
 
   molecule:
     name: Molecule

--- a/roles/icinga_agent/molecule/default/molecule.yml
+++ b/roles/icinga_agent/molecule/default/molecule.yml
@@ -20,8 +20,32 @@ platforms:
     privileged: true
     pre_build_image: true
     command: ""
+  - name: debian13
+    image: geerlingguy/docker-debian13-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
+  - name: ubuntu2404
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
+  - name: ubuntu2604
+    image: geerlingguy/docker-ubuntu2604-ansible:latest
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/roles/icinga_agent/molecule/default/prepare.yml
+++ b/roles/icinga_agent/molecule/default/prepare.yml
@@ -3,82 +3,70 @@
   hosts: all
   tasks:
     - name: Install epel repo
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.yum:
         name: epel-release
         state: installed
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Import icinga2 key
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.rpm_key:
         state: present
         key: https://packages.icinga.com/icinga.key
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install icinga2 repo
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.get_url:
         url: https://packages.icinga.com/centos/ICINGA-release.repo
         dest: /etc/yum.repos.d/ICINGA-release.repo
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install icinga2 basic packages
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         name: gnupg
         state: present
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'
 
-    - name: Add icinga2 repo key
-      ansible.builtin.apt_key:
-        url: http://packages.icinga.com/icinga.key
-        state: present
-      when: ansible_facts.os_family == 'Debian'
+    - name: Add icinga2 repo key on debian
+      when: ansible_facts.distribution == "Debian"
+      ansible.builtin.apt:
+        deb: "https://packages.icinga.com/icinga-archive-keyring_latest+{{ ansible_facts.distribution | lower }}{{ ansible_facts.distribution_major_version }}.deb"
 
-    - name: Add icinga2 repository on debian 11
+    - name: Add icinga2 repo key on ubuntu
+      when: ansible_facts.distribution == "Ubuntu"
+      ansible.builtin.apt:
+        deb: "https://packages.icinga.com/icinga-archive-keyring_latest+{{ ansible_facts.distribution | lower }}{{ ansible_facts.distribution_version }}.deb"
+
+    - name: Add icinga2 repository on debian
+      when: ansible_facts.distribution == "Debian"
       ansible.builtin.apt_repository:
         repo: "{{ item }}"
         state: present
         update_cache: true
       with_items:
-        - deb http://packages.icinga.com/debian icinga-bullseye main
-        - deb-src http://packages.icinga.com/debian icinga-bullseye main
-      when:
-        - ansible_facts.distribution == 'Debian'
-        - ansible_facts.distribution_major_version == "11"
+        - deb [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.distribution_release }} main
+        - deb-src [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.distribution_release }} main
 
-    - name: Add icinga2 repository on debian 12
+    - name: Add icinga2 repository on ubuntu
+      when: ansible_facts.distribution == "Ubuntu"
       ansible.builtin.apt_repository:
         repo: "{{ item }}"
         state: present
         update_cache: true
       with_items:
-        - deb http://packages.icinga.com/debian icinga-bookworm main
-        - deb-src http://packages.icinga.com/debian icinga-bookworm main
-      when:
-        - ansible_facts.distribution == 'Debian'
-        - ansible_facts.distribution_major_version == "12"
-
-    - name: Add icinga2 repository on ubuntu 2204
-      ansible.builtin.apt_repository:
-        repo: "{{ item }}"
-        state: present
-        update_cache: true
-      with_items:
-        - deb http://packages.icinga.com/ubuntu icinga-jammy main
-        - deb-src http://packages.icinga.com/ubuntu icinga-jammy main
-      when:
-        - ansible_facts.distribution == "Ubuntu"
-        - ansible_facts.distribution_major_version == "22"
+        - deb [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.lsb.codename }} main
+        - deb-src [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.lsb.codename }} main
 
     - name: Install icinga2 build dependencies
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         pkg: icinga2
         state: build-dep
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Install icinga2 basic packages
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         name: icinga2
         state: present
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'

--- a/roles/icinga_agent/molecule/default/verify.yml
+++ b/roles/icinga_agent/molecule/default/verify.yml
@@ -9,22 +9,22 @@
       register: result_icinga2_conf
 
     - name: Validate icinga2.conf results for RedHat based Distributions
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - result_icinga2_conf.state == 'file'
           - result_icinga2_conf.mode == '0640'
           - result_icinga2_conf.owner == 'icinga'
           - result_icinga2_conf.group == 'icinga'
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate icinga2.conf results for Debian based Distributions
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - result_icinga2_conf.state == 'file'
           - result_icinga2_conf.mode == '0640'
           - result_icinga2_conf.owner == 'nagios'
           - result_icinga2_conf.group == 'nagios'
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Verify that constants.conf exists
       ansible.builtin.file:
@@ -33,22 +33,22 @@
       register: result_constants_conf
 
     - name: Validate constants.conf results for RedHat based Distributions
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - result_constants_conf.state == 'file'
           - result_constants_conf.mode == '0640'
           - result_constants_conf.owner == 'icinga'
           - result_constants_conf.group == 'icinga'
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate constants.conf results for Debian based Distributions
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - result_constants_conf.state == 'file'
           - result_constants_conf.mode == '0640'
           - result_constants_conf.owner == 'nagios'
           - result_constants_conf.group == 'nagios'
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Verify that zones.conf exists
       ansible.builtin.file:
@@ -57,22 +57,22 @@
       register: result_zones_conf
 
     - name: Validate zones.conf results for RedHat based Distributions
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - result_zones_conf.state == 'file'
           - result_zones_conf.mode == '0640'
           - result_zones_conf.owner == 'icinga'
           - result_zones_conf.group == 'icinga'
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate zones.conf results for Debian based Distributions
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - result_zones_conf.state == 'file'
           - result_zones_conf.mode == '0640'
           - result_zones_conf.owner == 'nagios'
           - result_zones_conf.group == 'nagios'
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Verify that api.conf exists
       ansible.builtin.file:
@@ -81,22 +81,22 @@
       register: result_api_conf
 
     - name: Validate api.conf results for RedHat based Distributions
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - result_api_conf.state == 'file'
           - result_api_conf.mode == '0640'
           - result_api_conf.owner == 'icinga'
           - result_api_conf.group == 'icinga'
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate api.conf results for Debian based Distributions
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - result_api_conf.state == 'file'
           - result_api_conf.mode == '0640'
           - result_api_conf.owner == 'nagios'
           - result_api_conf.group == 'nagios'
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Verify that icinga2 package is installed
       ansible.builtin.package:

--- a/roles/icinga_plugins/molecule/default/molecule.yml
+++ b/roles/icinga_plugins/molecule/default/molecule.yml
@@ -20,8 +20,32 @@ platforms:
     privileged: true
     pre_build_image: true
     command: ""
+  - name: debian13
+    image: geerlingguy/docker-debian13-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
+  - name: ubuntu2404
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    command: ""
+  - name: ubuntu2604
+    image: geerlingguy/docker-ubuntu2604-ansible:latest
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/roles/icinga_plugins/molecule/default/prepare.yml
+++ b/roles/icinga_plugins/molecule/default/prepare.yml
@@ -3,10 +3,10 @@
   hosts: all
   tasks:
     - name: Install epel repo
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.yum:
         name: epel-release
         state: installed
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install git
       ansible.builtin.package:
@@ -15,77 +15,64 @@
         update_cache: "{{ (ansible_facts.pkg_mgr == 'apt') | ternary('true', omit) }}"
 
     - name: Import icinga2 key
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.rpm_key:
         state: present
         key: https://packages.icinga.com/icinga.key
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install icinga2 repo
+      when: ansible_facts.distribution == 'RedHat'
       ansible.builtin.get_url:
         url: https://packages.icinga.com/centos/ICINGA-release.repo
         dest: /etc/yum.repos.d/ICINGA-release.repo
-      when:
-        - ansible_facts.distribution == 'RedHat'
 
     - name: Install icinga2 basic packages
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         name: gnupg
         state: present
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'
 
-    - name: Add icinga2 repo key
-      ansible.builtin.apt_key:
-        url: http://packages.icinga.com/icinga.key
-        state: present
-      when: ansible_facts.os_family == 'Debian'
+    - name: Add icinga2 repo key on debian
+      when: ansible_facts.distribution == "Debian"
+      ansible.builtin.apt:
+        deb: "https://packages.icinga.com/icinga-archive-keyring_latest+{{ ansible_facts.distribution | lower }}{{ ansible_facts.distribution_major_version }}.deb"
 
-    - name: Add icinga2 repository on debian 11
+    - name: Add icinga2 repo key on ubuntu
+      when: ansible_facts.distribution == "Ubuntu"
+      ansible.builtin.apt:
+        deb: "https://packages.icinga.com/icinga-archive-keyring_latest+{{ ansible_facts.distribution | lower }}{{ ansible_facts.distribution_version }}.deb"
+
+    - name: Add icinga2 repository on debian
+      when: ansible_facts.distribution == "Debian"
       ansible.builtin.apt_repository:
         repo: "{{ item }}"
         state: present
         update_cache: true
       with_items:
-        - deb http://packages.icinga.com/debian icinga-bullseye main
-        - deb-src http://packages.icinga.com/debian icinga-bullseye main
-      when:
-        - ansible_facts.distribution == 'Debian'
-        - ansible_facts.distribution_major_version == "11"
+        - deb [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.distribution_release }} main
+        - deb-src [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.distribution_release }} main
 
-    - name: Add icinga2 repository on debian 12
+    - name: Add icinga2 repository on ubuntu
+      when: ansible_facts.distribution == "Ubuntu"
       ansible.builtin.apt_repository:
         repo: "{{ item }}"
         state: present
         update_cache: true
       with_items:
-        - deb http://packages.icinga.com/debian icinga-bookworm main
-        - deb-src http://packages.icinga.com/debian icinga-bookworm main
-      when:
-        - ansible_facts.distribution == 'Debian'
-        - ansible_facts.distribution_major_version == "12"
-
-    - name: Add icinga2 repository on ubuntu 2204
-      ansible.builtin.apt_repository:
-        repo: "{{ item }}"
-        state: present
-        update_cache: true
-      with_items:
-        - deb http://packages.icinga.com/ubuntu icinga-jammy main
-        - deb-src http://packages.icinga.com/ubuntu icinga-jammy main
-      when:
-        - ansible_facts.distribution == "Ubuntu"
-        - ansible_facts.distribution_major_version == "22"
+        - deb [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.lsb.codename }} main
+        - deb-src [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/{{ ansible_facts.distribution | lower }} icinga-{{ ansible_facts.lsb.codename }} main
 
     - name: Install icinga2 build dependencies
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         pkg: icinga2
         state: build-dep
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Install icinga2 basic packages
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         name: icinga2
         state: present
         update_cache: true
-      when: ansible_facts.os_family == 'Debian'

--- a/roles/icinga_plugins/molecule/default/verify.yml
+++ b/roles/icinga_plugins/molecule/default/verify.yml
@@ -3,18 +3,18 @@
   hosts: all
   tasks:
     - name: Set name of installation package based on distro
-      ansible.builtin.set_fact:
-        icinga_install_plugins:
-          - nagios-plugins-all
       when:
         - ansible_facts.os_family == 'RedHat'
         - ansible_facts.distribution_major_version | int is version('8', '<')
+      ansible.builtin.set_fact:
+        icinga_install_plugins:
+          - nagios-plugins-all
 
     - name: Set name of installation package based on distro
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.set_fact:
         icinga_install_plugins:
           - monitoring-plugins
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Include default vars from icinga_plugins roles
       ansible.builtin.include_vars:
@@ -44,35 +44,33 @@
       check_mode: false
 
     - name: Validate plugins belongs to the right user for Redhat based systems
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - item.pw_name == 'icinga'
           - item.gr_name == 'icinga'
       loop: "{{ files_in_plugins_dir.files }}"
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate plugins belongs to the right user for Debian based systems
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - item.pw_name == 'nagios'
           - item.gr_name == 'nagios'
       loop: "{{ files_in_plugins_dir.files }}"
-      when: ansible_facts.os_family == 'Debian'
 
     - name: Verify that package is installed
+      when: icinga_install_plugins is defined
       ansible.builtin.package:
         name: "{{ icinga_install_plugins }}"
         state: present
       register: result_installation
-      when:
-        - icinga_install_plugins is defined
 
     - name: Validate package is installed
+      when: icinga_install_plugins is defined
       ansible.builtin.assert:
         that:
           - result_installation is not changed
-      when:
-        - icinga_install_plugins is defined
 
     - name: Verify cloned check exists
       ansible.builtin.file:
@@ -82,6 +80,7 @@
       register: result_cloned_check
 
     - name: Validate that cloned check exists on Redhat based systems
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.assert:
         that:
           - result_cloned_check.state == 'file'
@@ -89,9 +88,9 @@
           - result_cloned_check.owner == 'icinga'
           - result_cloned_check.group == 'icinga'
           - result_cloned_check.changed == false
-      when: ansible_facts.os_family == 'RedHat'
 
     - name: Validate that cloned check exists on Debian based systems
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.assert:
         that:
           - result_cloned_check.state == 'file'
@@ -99,4 +98,3 @@
           - result_cloned_check.owner == 'nagios'
           - result_cloned_check.group == 'nagios'
           - result_cloned_check.changed == false
-      when: ansible_facts.os_family == 'Debian'


### PR DESCRIPTION
* use archive gpg key for each ubuntu and debian repository as described here: 
  * https://icinga.com/docs/icinga-2/latest/doc/02-installation/01-Debian/ 
  * https://icinga.com/docs/icinga-2/latest/doc/02-installation/02-Ubuntu/
* added molecule tests for ubuntu2404, ubuntu2604 and debian13