### PR TITLE
fix: ignore yaml line length

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -9,6 +9,9 @@ exclude_paths:
 # install collection dependencies
 offline: false
 
+skip_list:
+  - yaml[line-length]
+
 warn_list:
   - var-naming[no-role-prefix]
   - args[module]


### PR DESCRIPTION
because galaxy release workflow will destroy description every time